### PR TITLE
Add invalid swarm.best_pos check (#475)

### DIFF
--- a/pyswarms/backend/operators.py
+++ b/pyswarms/backend/operators.py
@@ -134,11 +134,18 @@ def compute_velocity(swarm, clamp, vh, bounds=None):
             * np.random.uniform(0, 1, swarm_size)
             * (swarm.pbest_pos - swarm.position)
         )
-        social = (
-            c2
-            * np.random.uniform(0, 1, swarm_size)
-            * (swarm.best_pos - swarm.position)
-        )
+        if swarm.best_pos.shape != (0,):
+            social = (
+                c2
+                * np.random.uniform(0, 1, swarm_size)
+                * (swarm.best_pos - swarm.position)
+            )
+        else:
+            social = (
+                c2
+                * np.random.uniform(0, 1, swarm_size)
+                * (swarm.pbest_pos - swarm.position)
+            )
         # Compute temp velocity (subject to clamping if possible)
         temp_velocity = (w * swarm.velocity) + cognitive + social
         updated_velocity = vh(

--- a/pyswarms/backend/swarms.py
+++ b/pyswarms/backend/swarms.py
@@ -100,7 +100,7 @@ class Swarm(object):
         validator=instance_of(np.ndarray),
     )
     best_cost = attrib(
-        type=float, default=np.inf, validator=instance_of((int, float))
+        type=float, default=np.float64(np.inf), validator=instance_of((int, float))
     )
     current_cost = attrib(
         type=np.ndarray,


### PR DESCRIPTION
This adds both a check whether best_pos is shapeless, as well as changing
the default initial value of best_cost so that no issues arise when copy()
is called on it without it having been modified.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

